### PR TITLE
Updated for consistency with phusion/baseimage boilerplate and lock down Erlang version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,44 @@
 # this stuff is worth it, you can buy me a beer in return
 # ----------------------------------------------------------------------------
 
+# Use phusion/baseimage as base image. To make your builds reproducible, make
+# sure you lock down to a specific version, not to `latest`!
+# See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md for
+# a list of version numbers.
+#
+# Usage Example : Run One-Off commands
+# where <VERSION> is one of the baseimage-docker version numbers.
+# See : https://github.com/phusion/baseimage-docker#oneshot for more examples.
+#
+#  docker run --rm -t -i phusion/baseimage:<VERSION> /sbin/my_init -- bash -l
+#
 # Thanks to @hqmq_ for the heads up
 FROM phusion/baseimage:0.9.13
 MAINTAINER Nizar Venturini @trenpixster
+
+# Important!  Update this no-op ENV variable when this Dockerfile
+# is updated with the current date. It will force refresh of all
+# of the base images and things like `apt-get update` won't be using
+# old cached versions when the Dockerfile is built.
+ENV REFRESHED_AT 2014-09-02
+
+# Set correct environment variables.
+ENV HOME /root
+
+# Regenerate SSH host keys. baseimage-docker does not contain any, so you
+# have to do that yourself. You may also comment out this instruction; the
+# init system will auto-generate one during boot.
+RUN /etc/my_init.d/00_regen_ssh_host_keys.sh
+
+# Baseimage-docker enables an SSH server by default, so that you can use SSH
+# to administer your container. In case you do not want to enable SSH, here's
+# how you can disable it. Uncomment the following:
+#RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
+# ...put your own build instructions here...
 
 # Set the locale
 RUN locale-gen en_US.UTF-8
@@ -17,10 +52,11 @@ ENV LC_ALL en_US.UTF-8
 
 WORKDIR /tmp
 
-# Update repos
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections # from https://github.com/phusion/baseimage-docker/issues/58
+# See : https://github.com/phusion/baseimage-docker/issues/58
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-RUN apt-get update
+# Update repos
+RUN apt-get -qq update
 
 # Install wget
 RUN apt-get install -y wget
@@ -29,21 +65,30 @@ RUN apt-get install -y wget
 RUN apt-get install -y unzip
 
 # Add Erlang Solutions repo
+# See : https://www.erlang-solutions.com/downloads/download-erlang-otp
 RUN echo "deb http://packages.erlang-solutions.com/ubuntu trusty contrib" >> /etc/apt/sources.list
 RUN wget http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
 RUN apt-key add erlang_solutions.asc
-RUN apt-get update
+RUN apt-get -qq update
 
-# Install Erlang
-RUN sudo apt-get install -y erlang
+# Download and Install Specific Version of Erlang
+RUN apt-get install -y erlang=1:17.1
 
-# Download and Install Elixir
+# Download and Install Specific Version of Elixir
 WORKDIR /elixir
-RUN wget https://github.com/elixir-lang/elixir/releases/download/v1.0.0-rc1/Precompiled.zip
+RUN wget -q https://github.com/elixir-lang/elixir/releases/download/v1.0.0-rc1/Precompiled.zip
 RUN unzip Precompiled.zip
-RUN ln -s  /elixir/bin/elixirc /usr/local/bin/elixirc
-RUN ln -s  /elixir/bin/elixir /usr/local/bin/elixir
+RUN rm -f Precompiled.zip
+RUN ln -s /elixir/bin/elixirc /usr/local/bin/elixirc
+RUN ln -s /elixir/bin/elixir /usr/local/bin/elixir
 RUN ln -s /elixir/bin/mix /usr/local/bin/mix
-RUN ln -s  /elixir/bin/iex /usr/local/bin/iex
+RUN ln -s /elixir/bin/iex /usr/local/bin/iex
+
+# Install local Elixir hex and rebar
+RUN /usr/local/bin/mix local.hex --force
+RUN /usr/local/bin/mix local.rebar --force
 
 WORKDIR /
+
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 #Elixir Dockerfile
 
-This dockerfile enables you to create your own latest [Elixir](http://www.elixir-lang.org) and [Erlang OTP](http://www.erlang.org/)
-docker image.
+This Dockerfile enables you to create your own [Elixir](http://www.elixir-lang.org) and [Erlang OTP](http://www.erlang.org/) docker image using the latest version of both.
+
+This Dockerfile is based on the [phusion/baseimage](https://registry.hub.docker.com/u/phusion/baseimage/) docker image which is designed to overcome some issues using base Ubuntu in a Docker container.
 
 Have fun and feel free to submit any changes!


### PR DESCRIPTION
- Comply with phusion/baseimage boilerplate setup. Especially running
  init scripts.
- Use ‘ENV REFRESHED_AT’ var per The Docker Book to periodically force
  refresh of underlying images so things like apt-get update won’t go
  stale.
- Lock down the Erlang version to 1:17.1 so builds are consistent and
  explicit.
- Install current hex and rebar local scripts.
- Run apt-get update more quietly with -qq
- Run wget quietly
- Remove no longer needed Precompiled Elixir zip file.
- Clean up apt-get and tmp dirs
- Add additional comments and links for learning more.
- Show example usage for running one-off scripts with phusion/baseimage
- Provide commented out line for disabling SSH for those who don’t want
  it.
- Update README.md with link to phusion/baseimage info.
