### PR TITLE
Combine commands when applicable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,18 +61,14 @@ WORKDIR /tmp
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Update repos
-RUN apt-get -qq update && apt-get install -y \
+RUN echo "deb http://packages.erlang-solutions.com/ubuntu trusty contrib" >> /etc/apt/sources.list && \
+    apt-key adv --fetch-keys http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
+    apt-get -qq update && apt-get install -y \
+    erlang=1:17.3.2 \
     git \
     unzip \
-    wget
-
-# Add Erlang Solutions repo
-# See : https://www.erlang-solutions.com/downloads/download-erlang-otp
-RUN echo "deb http://packages.erlang-solutions.com/ubuntu trusty contrib" >> /etc/apt/sources.list && \
-    wget http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
-    apt-key add erlang_solutions.asc && \
-    apt-get -qq update && \
-    apt-get install -y erlang=1:17.3.2
+    wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download and Install Specific Version of Elixir
 WORKDIR /elixir
@@ -89,6 +85,3 @@ RUN /usr/local/bin/mix local.hex --force && \
     /usr/local/bin/mix local.rebar --force
 
 WORKDIR /
-
-# Clean up APT when done.
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Thanks for being awesome about keeping this up to date! I noticed during a fresh build the other day that there are a _lot_ of layers coming out of this base image, so this is a PR to help clean that up a little. All I've done is combine run commands when applicable, which should have a few side effects.
- Meaningful build cache
- Fewer FS layers

All in all, this takes a build from 32 steps to ~~18~~ 16 while still staying fairly readable (imo). It also decreases the image size by 79.6mb (which isn't massive, but at least it's a little something).

Update: By using `apt-key adv --fetch-keys`, we don't need wget and multiple apt-get update / installs. Also by moving the cleanup to the layer that apt-get actually runs in, we're able to actually clean things up _in that layer_, which is what we really want to do.
