### PR TITLE
Force aptitude to fetch Erlang 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN echo "deb http://packages.erlang-solutions.com/ubuntu trusty contrib" >> /etc/apt/sources.list && \
     apt-key adv --fetch-keys http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc && \
     apt-get -qq update && apt-get install -y \
-    esl-erlang \
+    esl-erlang=1:18.2 \
     git \
     unzip \
     build-essential \


### PR DESCRIPTION
Elixir 1.3 still has some problems here and there when compiling with Erlang 19. To make sure we don't break any development machines, it's a good idea to pin the `18` version. Some other libraries are not compatible yet.